### PR TITLE
Install missing dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,3 +16,4 @@ gem 'middleman-deploy', '~> 2.0.0.pre.alpha', git: 'https://github.com/inz/middl
 
 # To generate backend docs
 gem 'yard'
+gem 'redcarpet'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,6 +120,7 @@ GEM
     rb-fsevent (0.9.8)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
+    redcarpet (2.3.0)
     sass (3.4.23)
     servolux (0.12.0)
     thor (0.19.4)
@@ -139,9 +140,10 @@ DEPENDENCIES
   middleman-compass (>= 4.0.0)
   middleman-deploy (~> 2.0.0.pre.alpha)!
   middleman-livereload
+  redcarpet
   tzinfo-data
   wdm (~> 0.1.0)
   yard
 
 BUNDLED WITH
-   1.12.3
+   1.14.3

--- a/config.rb
+++ b/config.rb
@@ -70,7 +70,7 @@ configure :build do
   # Pull in front end docs
   activate :external_pipeline,
     name: :frontend_docs,
-    command: "mkdir -p .tmp && cd .tmp && rm -rf frontend && #{fetch_code_command(:frontend, config[:frontend_repo_url])} && npm install --ignore-scripts && npm run typedoc -- --out doc/frontend/",
+    command: "mkdir -p .tmp && cd .tmp && rm -rf frontend && #{fetch_code_command(:frontend, config[:frontend_repo_url])} && sed -i -e 's/~0.5.5/0.5.5/g' package.json && npm install --ignore-scripts && npm run typedoc -- --out doc/frontend/",
     source: ".tmp/frontend/doc",
     latency: 2
 end

--- a/wercker.yml
+++ b/wercker.yml
@@ -28,6 +28,10 @@ build:
                 sudo apt-get install -y nodejs
         - bundle-install
         - script:
+            name: Install dependencies
+            code: |
+              gem install redcarpet
+        - script:
             name: build site
             code: bundle exec middleman build
         - script:


### PR DESCRIPTION
The external pipeline step used by middleman does not use the middleman bundle, so we install them globally.